### PR TITLE
Den 3147 Reading and writing a serial number to the Orion board's EEPROM

### DIFF
--- a/cycfx2prog-0.47/cycfx2dev.cc
+++ b/cycfx2prog-0.47/cycfx2dev.cc
@@ -1069,7 +1069,7 @@ int CypressFX2Device::SerialNumberWrite(const unsigned char *ctl_buf, size_t ctl
         return(rv);
 }
 
-int CypressFX2Device::OrionSerialNumberRead(const unsigned char *ctl_buf, size_t ctl_buf_size)
+int CypressFX2Device::OrionSerialNumberRead(unsigned char *ctl_buf, size_t ctl_buf_size)
 {
         // Serial number format is 1 byte length, 1 to 64 bytes serial
         // number value (ASCII), 2 bytes CRC-16 CCITT

--- a/cycfx2prog-0.47/cycfx2dev.h
+++ b/cycfx2prog-0.47/cycfx2dev.h
@@ -36,7 +36,6 @@ class CypressFX2Device
 		int _ProgramIHexLine(const char *buf,const char *path,int line);
                 // Internally used to calculate a serial number's checksum
                 unsigned short Computecrc16(const unsigned char* data_p, unsigned char length);
-	private:
 		CypressFX2Device(const CypressFX2Device &);
 		void operator=(const CypressFX2Device &);
 	public:

--- a/cycfx2prog-0.47/cycfx2dev.h
+++ b/cycfx2prog-0.47/cycfx2dev.h
@@ -34,6 +34,8 @@ class CypressFX2Device
 		// Internally used: Program one line of an Intel HEX file. 
 		// The arguments path and line are just needed for error reporting. 
 		int _ProgramIHexLine(const char *buf,const char *path,int line);
+                // Internally used to calculate a serial number's checksum
+                unsigned short Computecrc16(const unsigned char* data_p, unsigned char length);
 	private:
 		CypressFX2Device(const CypressFX2Device &);
 		void operator=(const CypressFX2Device &);
@@ -123,6 +125,12 @@ class CypressFX2Device
 
                 // Write a serial number to the FX2 EEPROM
                 int SerialNumberWrite(const unsigned char *ctl_buf,
+                        size_t ctl_buf_size);
+                // Read the serial number from the Orion board
+                int OrionSerialNumberRead(const unsigned char *ctl_buf,
+                        size_t ctl_buf_size);
+                // Write a serial number to the Orion board
+                int OrionSerialNumberWrite(const unsigned char *ctl_buf,
                         size_t ctl_buf_size);
                 // Write a file to the FX2's eeprom
                 int ProgramFx2BinFile(const char *path);

--- a/cycfx2prog-0.47/cycfx2dev.h
+++ b/cycfx2prog-0.47/cycfx2dev.h
@@ -126,7 +126,7 @@ class CypressFX2Device
                 int SerialNumberWrite(const unsigned char *ctl_buf,
                         size_t ctl_buf_size);
                 // Read the serial number from the Orion board
-                int OrionSerialNumberRead(const unsigned char *ctl_buf,
+                int OrionSerialNumberRead(unsigned char *ctl_buf,
                         size_t ctl_buf_size);
                 // Write a serial number to the Orion board
                 int OrionSerialNumberWrite(const unsigned char *ctl_buf,

--- a/cycfx2prog-0.47/cycfx2prog.cc
+++ b/cycfx2prog-0.47/cycfx2prog.cc
@@ -742,7 +742,7 @@ int main(int argc,char **arg)
                 else if(!strcmp(cmd,"setorionserial"))
                 {
                     // if a serial number string has been provided and no more than 32 characters
-                    if(a[0] && *a[0] && (strlen(a[0]) < 33))
+                    if(a[0] && *a[0] && (strlen(a[0]) < 65))
                     {
                         fprintf(stderr,"Writing serial number %s\n", a[0]);
 


### PR DESCRIPTION
Added functions to read and write a serial number to the FX2's I2C connected EEPROM on the Orion board.